### PR TITLE
fix: rename github_token to bot_token in workflow secrets

### DIFF
--- a/.github/workflows/claude-agent-pipeline.yml
+++ b/.github/workflows/claude-agent-pipeline.yml
@@ -55,8 +55,8 @@ on:
       anthropic_auth_token:
         description: 'Anthropic API token (for Moonshot)'
         required: false
-      github_token:
-        description: 'GitHub token'
+      bot_token:
+        description: 'GitHub token for API operations'
         required: true
 
 jobs:
@@ -89,7 +89,7 @@ jobs:
         uses: batumi-works/actions-lib/actions/claude-setup@v1
         with:
           claude_oauth_token: ${{ secrets.claude_oauth_token || secrets.anthropic_auth_token }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           git_user_name: ${{ inputs.git_user_name }}
           git_user_email: ${{ inputs.git_user_email }}
           fetch_depth: 0
@@ -99,7 +99,7 @@ jobs:
         if: github.event_name == 'issues' || github.event_name == 'issue_comment'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: check-bot-status
           issue_number: ${{ github.event.issue.number }}
           bot_username: ${{ inputs.bot_username }}
@@ -188,7 +188,7 @@ jobs:
         if: (github.event_name == 'issues' || github.event_name == 'issue_comment') && steps.bot-status.outputs.should_process == 'true' && steps.commit.outputs.has_changes == 'true' && steps.find-prp.outputs.latest_prp != ''
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |
@@ -213,7 +213,7 @@ jobs:
         if: (github.event_name == 'issues' || github.event_name == 'issue_comment') && steps.bot-status.outputs.should_process == 'true' && steps.commit.outputs.has_changes == 'false'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |

--- a/.github/workflows/claude-prp-pipeline.yml
+++ b/.github/workflows/claude-prp-pipeline.yml
@@ -50,8 +50,8 @@ on:
       anthropic_auth_token:
         description: 'Anthropic API token (for Moonshot)'
         required: false
-      github_token:
-        description: 'GitHub token'
+      bot_token:
+        description: 'GitHub token for API operations'
         required: true
 
 jobs:
@@ -84,7 +84,7 @@ jobs:
         uses: batumi-works/actions-lib/actions/claude-setup@v1
         with:
           claude_oauth_token: ${{ secrets.claude_oauth_token || secrets.anthropic_auth_token }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           git_user_name: ${{ inputs.git_user_name }}
           git_user_email: ${{ inputs.git_user_email }}
           fetch_depth: 0
@@ -148,7 +148,7 @@ jobs:
         if: steps.prp.outputs.has_prp == 'true' && steps.commit.outputs.has_changes == 'true'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: create-pr
           pr_title: "feat: implement ${{ steps.prp.outputs.prp_name }}"
           pr_head: ${{ steps.prp.outputs.branch_name }}
@@ -174,7 +174,7 @@ jobs:
         if: steps.prp.outputs.has_prp == 'true' && steps.commit.outputs.has_changes == 'true'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |
@@ -191,7 +191,7 @@ jobs:
         if: steps.prp.outputs.has_prp == 'true' && steps.commit.outputs.has_changes == 'false'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |


### PR DESCRIPTION
## Summary

This PR renames the \"github_token\" secret to \"bot_token\" in both workflow files to better reflect its purpose as a GitHub token specifically for API operations.

## Changes Made

### claude-agent-pipeline.yml
- Changed secret name from \"github_token\" to \"bot_token\"
- Updated secret description from \"GitHub token\" to \"GitHub token for API operations\"
- Updated all usages of \"secrets.github_token\" to \"secrets.bot_token\"

### claude-prp-pipeline.yml  
- Changed secret name from \"github_token\" to \"bot_token\"
- Updated secret description from \"GitHub token\" to \"GitHub token for API operations\"
- Updated all usages of \"secrets.github_token\" to \"secrets.bot_token\"

## Impact

This is a breaking change for workflows that use these reusable workflows. Consumers will need to update their workflow configurations to use \"bot_token\" instead of \"github_token\" when calling these workflows.

## Testing

- [x] Verified all instances of \"github_token\" have been replaced with \"bot_token\"
- [x] Verified secret descriptions have been updated appropriately
- [x] No functional changes to the workflows themselves

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to rename the GitHub API authentication secret from `github_token` to `bot_token` for improved clarity.
  * Adjusted related descriptions and references in workflow steps to reflect the new secret name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->