### PR TITLE
fix: rename github_token to bot_token to avoid reserved name conflict

### DIFF
--- a/.github/workflows/claude-agent-pipeline.yml
+++ b/.github/workflows/claude-agent-pipeline.yml
@@ -55,8 +55,8 @@ on:
       anthropic_auth_token:
         description: 'Anthropic API token (for Moonshot)'
         required: false
-      github_token:
-        description: 'GitHub token'
+      bot_token:
+        description: 'GitHub token for bot operations'
         required: true
 
 jobs:
@@ -89,7 +89,7 @@ jobs:
         uses: batumi-works/actions-lib/actions/claude-setup@v1
         with:
           claude_oauth_token: ${{ secrets.claude_oauth_token || secrets.anthropic_auth_token }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           git_user_name: ${{ inputs.git_user_name }}
           git_user_email: ${{ inputs.git_user_email }}
           fetch_depth: 0
@@ -99,7 +99,7 @@ jobs:
         if: github.event_name == 'issues' || github.event_name == 'issue_comment'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: check-bot-status
           issue_number: ${{ github.event.issue.number }}
           bot_username: ${{ inputs.bot_username }}
@@ -188,7 +188,7 @@ jobs:
         if: (github.event_name == 'issues' || github.event_name == 'issue_comment') && steps.bot-status.outputs.should_process == 'true' && steps.commit.outputs.has_changes == 'true' && steps.find-prp.outputs.latest_prp != ''
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |
@@ -213,7 +213,7 @@ jobs:
         if: (github.event_name == 'issues' || github.event_name == 'issue_comment') && steps.bot-status.outputs.should_process == 'true' && steps.commit.outputs.has_changes == 'false'
         uses: batumi-works/actions-lib/actions/github-operations@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           operation: comment-issue
           issue_number: ${{ github.event.issue.number }}
           comment_body: |


### PR DESCRIPTION
## Summary
- Fixed workflow execution failures caused by using the reserved name `github_token` as a secret parameter
- Renamed `github_token` to `bot_token` in the workflow_call secrets definition
- Updated all references to use the new `bot_token` name

## Problem
GitHub Actions reserves the name `github_token` and it cannot be used as a secret parameter in `workflow_call`. This was causing workflow failures with the error:
```
secret name `github_token` within `workflow_call` can not be used since it would collide with system reserved name
```

## Solution
Renamed the secret from `github_token` to `bot_token` throughout the reusable workflow.

## Test Plan
- [x] Verified all references to `github_token` in secrets have been updated
- [ ] Test workflows that use this reusable workflow to ensure they pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to use a new secret name for authentication. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->