### PR TITLE
🚨 Fix: Resolve merge conflict causing workflow startup failures

### DIFF
--- a/.github/workflows/claude-prp-pipeline.yml
+++ b/.github/workflows/claude-prp-pipeline.yml
@@ -50,11 +50,7 @@ on:
       anthropic_auth_token:
         description: 'Anthropic API token (for Moonshot)'
         required: false
-<<<<<<< HEAD
       bot_token:
-=======
-      github_token:
->>>>>>> 4a876f0 (docs: update workflow secret descriptions for clarity)
         description: 'GitHub token for API operations'
         required: true
 


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes a critical merge conflict in the `claude-prp-pipeline.yml` workflow that was causing startup failures when external repositories try to call this reusable workflow.

## Problem

The workflow file contained unresolved merge conflict markers:
```yaml
<<<<<<< HEAD
      bot_token:
=======
      github_token:
>>>>>>> 4a876f0 (docs: update workflow secret descriptions for clarity)
```

This invalid YAML syntax caused GitHub Actions to fail during workflow parsing, resulting in immediate "startup_failure" errors before any steps could run.

## Solution

- Resolved the merge conflict by choosing `bot_token` as the secret name
- This maintains consistency with `claude-agent-pipeline.yml` 
- Avoids conflicts with the reserved `GITHUB_TOKEN` name

## Impact

This fix allows private repositories to successfully call this public reusable workflow without startup failures.

## Testing

- Verified YAML syntax is valid
- Confirmed all token references in the workflow use `bot_token` consistently
- Matches the pattern used in `claude-agent-pipeline.yml`

Fixes the issue reported where private repository `pSEO-builder` was experiencing persistent startup failures when calling workflows from this public `actions-lib` repository.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow configuration to use a more descriptive secret name for the GitHub token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->